### PR TITLE
Return success or failure from caas_base.pod_spec_set

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ def create_container():
     image_info = layer.docker_resource.get_info('my-image')
     config = hookenv.config()
 
-    layer.caas_base.pod_spec_set({
+    success = layer.caas_base.pod_spec_set({
         'containers': [
             {
                 'name': 'my-charm',
@@ -77,6 +77,9 @@ def create_container():
             },
         ],
     })
-    layer.status.maintenance('creating container')
-    set_flag('charm.my-charm.started')
+    if success:
+        layer.status.maintenance('creating container')
+        set_flag('charm.my-charm.started')
+    else:
+        layer.status.blocked('k8s spec failed to deploy')
 ```

--- a/lib/charms/layer/caas_base.py
+++ b/lib/charms/layer/caas_base.py
@@ -21,12 +21,13 @@ def pod_spec_set(spec):
         ret = subprocess.call(cmd)
         os.remove(spec_file.name)
         if ret == 0:
-            return
+            return True
     except OSError as e:
         if e.errno != errno.ENOENT:
             raise
     log_message = 'pod-spec-set failed'
     log(log_message, level='INFO')
+    return False
 
 
 def init_config_states():


### PR DESCRIPTION
pod_spec_set needs to return success status so charms can expose
failures to the user, advising them to check the logs.