### PR TITLE
Prefer libs from charm over image

### DIFF
--- a/hooks/hook.template
+++ b/hooks/hook.template
@@ -2,7 +2,7 @@
 
 # Load modules from $JUJU_CHARM_DIR/lib
 import sys
-sys.path.append('lib')
+sys.path.insert(0, 'lib')
 
 from charms.layer import caas_base
 caas_base.init_config_states()


### PR DESCRIPTION
The base image has a slightly older version of charmhelpers baked in.  (Specifically, for my use-case, it's missing `goal_state`.)  Changing the order of the path component makes the charms prefer the version baked into the charm rather than the one baked into the base image.  It also allows for other library updates to be pulled into the charm via `wheelhouse.txt`.