### PR TITLE
Fix charm building to work with new WheelhouseTactic updates

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -4,4 +4,4 @@ description: Base layer for CAAS charms.
 includes:
   - 'layer:options'
 tactics:
-  - tactics.wheelhouse.WheelhouseTactic
+  - tactics.wheelhouse.CAASWheelhouseTactic

--- a/tactics/wheelhouse.py
+++ b/tactics/wheelhouse.py
@@ -1,68 +1,22 @@
 import logging
 
-from charmtools.build.tactics import ExactMatch, Tactic
+from charmtools.build.tactics import WheelhouseTactic
+from charmtools.build import builder
 from charmtools import utils
 
 log = logging.getLogger(__name__)
 
 
-class WheelhouseTactic(ExactMatch, Tactic):
-    """
-    This tactic matches the file `wheelhouse.txt` and is called to process
-    that file.
-    """
-    kind = "dynamic"
-    FILENAME = 'wheelhouse.txt'
-
-    def __init__(self, *args, **kwargs):
-        super(WheelhouseTactic, self).__init__(*args, **kwargs)
-        self.tracked = []
-        self.previous = []
-
+class CAASWheelhouseTactic(WheelhouseTactic):
     @property
     def dest(self):
         return self.target.directory / 'lib'
 
-    def __str__(self):
-        return "Building wheelhouse in {}".format(self.dest)
-
-    def combine(self, existing):
-        """
-        Maintain a list of the tactic instances for each previous layer's
-        `wheelhouse.txt` file, in order.
-        """
-        self.previous = existing.previous + [existing]
-        return self
-
-    def __call__(self):
-        """
-        Process the wheelhouse.txt file.
-
-        This gets called once on the tactic instance for the highest level
-        layer which contains a `wheelhouse.txt` file (e.g., the charm layer).
-        It then iterates the instances representing all of the previous
-        layers, in order, so that higher layers take precedence over base
-        layers.
-
-        For each layer, its `wheelhouse.txt` is pip installed into a temp
-        directory and all files that end up in that temp dir are recorded
-        for tracking ownership in the build reporting, and then the temp
-        dir's contents are copied into the charm's `lib/` dir.
-
-        The installation happens separately for each layer's `wheelhouse.txt`
-        (rather than just combining them into a single `wheelhouse.txt`)
-        because files created by a given layer's `wheelhouse.txt` should be
-        signed by that layer in the report to properly detect changes, etc.
-        """
-        # recursively process previous layers, depth-first
-        for tactic in self.previous:
-            tactic()
-        # process this layer
-        self.dest.mkdir_p()
+    def _add(self, wheelhouse, *reqs):
         with utils.tempdir(chdir=False) as temp_dir:
             # install into a temp dir first to track new and updated files
             utils.Process(
-                ('pip3', 'install', '-t', str(temp_dir), '-r', self.entity)
+                ('pip3', 'install', '-t', str(temp_dir), *reqs)
             ).exit_on_error()()
             # clear out cached compiled files (there shouldn't really be a
             # reason to include these in the charms; they'll just be
@@ -81,17 +35,7 @@ class WheelhouseTactic(ExactMatch, Tactic):
             # copy everything over from temp_dir to charm's /lib
             temp_dir.merge_tree(self.dest)
 
-    def sign(self):
-        """return sign in the form {relpath: (origin layer, SHA256)}
 
-        This is how the report of changed files is created.
-        """
-        sigs = {}
-        # recursively have all previous layers sign their files, depth-first
-        for tactic in self.previous:
-            sigs.update(tactic.sign())
-        # sign ownership of all files this layer created or updated
-        for d in self.tracked:
-            relpath = d.relpath(self.target.directory)
-            sigs[relpath] = (self.layer.url, "dynamic", utils.sign(d))
-        return sigs
+# Completely patch out the base WheelhouseTactic to work around:
+# https://github.com/juju/charm-tools/issues/596
+builder.WheelhouseTactic = CAASWheelhouseTactic


### PR DESCRIPTION
This fork of the WheelhouseTactic got significantly out of date from the base, and charm-tools PR #585 broke the tactic override mechanism (see https://github.com/juju/charm-tools/issues/596). This addresses both by working around the tactic override issue and bringing the custom tactic into line with the base by making it a subclass.

Fixes #27